### PR TITLE
Byteswap os x

### DIFF
--- a/src/sypexgeo.cc
+++ b/src/sypexgeo.cc
@@ -7,7 +7,13 @@
 
 #include "./sypexgeo.h"
 #include <arpa/inet.h>
+#if defined(Q_OS_MAC)
+#include <libkern/OSByteOrder.h>
+#define bswap_16(x) OSSwapInt16(x)
+#define bswap_32(x) OSSwapInt32(x)
+#else
 #include <byteswap.h>
+#endif
 #include <cstdlib>
 #include <cstring>
 #include <iostream>

--- a/src/sypexgeo.cc
+++ b/src/sypexgeo.cc
@@ -7,7 +7,7 @@
 
 #include "./sypexgeo.h"
 #include <arpa/inet.h>
-#if defined(Q_OS_MAC)
+#if defined(__APPLE__)
 #include <libkern/OSByteOrder.h>
 #define bswap_16(x) OSSwapInt16(x)
 #define bswap_32(x) OSSwapInt32(x)

--- a/src/sypexgeo_node.cc
+++ b/src/sypexgeo_node.cc
@@ -76,6 +76,7 @@ NAN_METHOD(SypexGeoNode::GetCountry) {
     size_t count;
     char* ip = NanCString(args[0]->ToString(), &count);
     const char *country = obj->geo.getCountry(ip);
+    printf("%s", country);
     delete ip;
 
     if (NULL == country) {

--- a/src/sypexgeo_node.cc
+++ b/src/sypexgeo_node.cc
@@ -66,6 +66,7 @@ NAN_METHOD(SypexGeoNode::New) {
 }
 
 NAN_METHOD(SypexGeoNode::GetCountry) {
+    printf("here lol");
     NanScope();
 
     if (args.Length() < 1)


### PR DESCRIPTION
Исправляем ошибку связанную с отсутствием byteswap.h на OSX. Вместо него есть /usr/includes/libkern/OSByteOrder.h